### PR TITLE
Update refrence from draft to RFC 5869

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 HKDF - HMAC Key Derivation Function
 ===================================
 
-This module implements the HMAC Key Derivation function, defined at
+This module implements the HMAC Key Derivation function as specified in RFC 5869:
 
-    http://tools.ietf.org/html/draft-krawczyk-hkdf-01
+    https://www.rfc-editor.org/rfc/rfc5869
 
 There are two interfaces: a functional interface, with separate extract
 and expand functions as defined in the draft RFC, and a wrapper class for
@@ -41,7 +41,7 @@ Example::
 To use the wrapper class, instantiate the ``Hkdf()`` class with a salt, input
 key material, and optionally, a hash function. Note that **the default hash function
 for the wrapper class is SHA-256**, which differs from the default for the functional
-interface. You may then call ``expand([info], [length])`` on the Hkdf instance to 
+interface. You may then call ``expand([info], [length])`` on the Hkdf instance to
 generate output key material::
 
     kdf = Hkdf(unhexlify(b"8e94ef805b93e683ff18"), b"asecretpassword", hash=hashlib.sha512)
@@ -57,5 +57,3 @@ Changelog
 Please report any bugs at
 
     https://www.github.com/casebeer/python-hkdf
-
-

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ This module implements the HMAC Key Derivation function as specified in RFC 5869
     https://www.rfc-editor.org/rfc/rfc5869
 
 There are two interfaces: a functional interface, with separate extract
-and expand functions as defined in the draft RFC, and a wrapper class for
+and expand functions as defined in the RFC, and a wrapper class for
 these functions.
 
 Functional interface
@@ -15,14 +15,14 @@ Functional interface
 To use the functional interface, pass the pseudorandom key generated
 by ``hmac_extract([salt], [input key material])`` to ``hmac_expand(...)``.
 ``salt`` should be a random, non-secret, site-specific string, but may be
-set to None. See section 3.1 of the HKDF draft for more details.
+set to None. See section 3.1 of the HKDF RFC for more details.
 
 In addition to the PRK output by ``hmac_extract()``, ``hmac_expand()`` takes an
 ``info`` argument, which permits generating multiple keys based on the
 same PRK, and a ``length`` argument, which defines the number of bytes
 of output key material to generate. ``length`` must be less than or equal
 to 255 time the block size, in bytes, of the hash function being used.
-See section 3.2 of the HKDF draft for more information on using the ``info``
+See section 3.2 of the HKDF RFC for more information on using the ``info``
 argument.
 
 The hash function to use can be specified for both ``hmac_extract()`` and

--- a/hkdf.py
+++ b/hkdf.py
@@ -16,8 +16,8 @@ def hkdf_extract(salt, input_key_material, hash=hashlib.sha512):
 	salt should be a random, application-specific byte string. If
 	salt is None or the empty string, an all-zeros string of the same
 	length as the hash's block size will be used instead per the RFC.
-	
-	See the HKDF draft RFC and paper for usage notes.
+
+	See the HKDF RFC and paper for usage notes.
 	'''
 	hash_len = hash().digest_size
 	if salt == None or len(salt) == 0:
@@ -28,7 +28,7 @@ def hkdf_expand(pseudo_random_key, info=b"", length=32, hash=hashlib.sha512):
 	'''
 	Expand `pseudo_random_key` and `info` into a key of length `bytes` using
 	HKDF's expand function based on HMAC with the provided hash (default
-	SHA-512). See the HKDF draft RFC and paper for usage notes.
+	SHA-512). See the HKDF RFC and paper for usage notes.
 	'''
 	hash_len = hash().digest_size
 	length = int(length)
@@ -51,8 +51,8 @@ class Hkdf(object):
 	def __init__(self, salt, input_key_material, hash=hashlib.sha256):
 		'''
 		Extract a pseudorandom key from `salt` and `input_key_material` arguments.
-		
-		See the HKDF draft RFC for guidance on setting these values. The constructor
+
+		See the HKDF RFC for guidance on setting these values. The constructor
 		optionally takes a `hash` arugment defining the hash function use,
 		defaulting to hashlib.sha256.
 		'''
@@ -66,7 +66,6 @@ class Hkdf(object):
 		- info - context to generate the OKM
 		- length - length in bytes of the key to generate
 
-		See the HKDF draft RFC for guidance.
+		See the HKDF RFC for guidance.
 		'''
 		return hkdf_expand(self._prk, info, length, self._hash)
-

--- a/tests.py
+++ b/tests.py
@@ -20,8 +20,8 @@ try:
 except ImportError as e:
 	def assert_equals(a, b):
 		'''
-		Assert a and b are equal. 
-		
+		Assert a and b are equal.
+
 		Assume a and b are raw binary data and escape before printing.
 		'''
 		try:
@@ -53,7 +53,7 @@ class TestCase(UserDict):
 def decode_hex(s):
 	return codecs.decode(s, "hex_codec")
 
-#### HKDF test vectors from draft RFC
+#### HKDF test vectors from RFC
 
 test_vectors = {}
 
@@ -181,7 +181,7 @@ def test_wrapper_class():
 def check_fun_tv(tv):
 	'''
 	Generate and check HKDF pseudorandom key and output key material for a specific test vector
-	
+
 	PRK = HKDF-Extract([test vector values])
 	OKM = HKDF-Expand(PRK, [test vector values])
 	'''


### PR DESCRIPTION
The HKDF reference points to the draft that expired 14 years ago. This set of changes the reference to the official IETF RFC 5869. It also changes, removes the use of "draft" to "RFC" throughout the README as well as in comments in the code. This set of changes does not change the actual functionality of the code.